### PR TITLE
test(mailer): add test for mailer service and refactor mocks

### DIFF
--- a/server/src/tests/__mocks__/mock-prisma-models.ts
+++ b/server/src/tests/__mocks__/mock-prisma-models.ts
@@ -1,0 +1,29 @@
+import { Role } from "@prisma/client";
+
+export const mockUser = {
+  id: 1,
+  email: "test@example.com",
+  username: "testuser",
+  role: Role.USER,
+  createdAt: new Date()
+};
+
+export const mockResetTokenRecord = {
+  id: "1",
+  token: "reset_token",
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  userId: 1,
+  user: mockUser,
+  revoked: false
+}
+
+export const mockRefreshTokenRecord = {
+  id: '1',
+  token: "refresh_token",
+  revoked: false,
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 24 * 14 * 60 * 60 * 1000),
+  userId: 1,
+  user: mockUser
+};

--- a/server/src/tests/__mocks__/nodemailer.ts
+++ b/server/src/tests/__mocks__/nodemailer.ts
@@ -1,0 +1,9 @@
+import type { Transporter } from 'nodemailer';
+import { vi } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+export const mockTransporter = mockDeep<Transporter>();
+
+export const createTransport = vi.fn(() => mockTransporter);
+
+export default { createTransport };

--- a/server/src/tests/auth/login.test.ts
+++ b/server/src/tests/auth/login.test.ts
@@ -1,21 +1,13 @@
-import { Role } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { prisma } from "../../lib/__mocks__/prisma";
 import { login } from "../../services/auth.service";
+import { mockUser } from "../__mocks__/mock-prisma-models";
 
 const mockAccessToken = "access_token";
 const mockRefreshToken = "refresh_token";
 
 const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000;
-
-const mockUser = {
-  id: 1,
-  email: "test@example.com",
-  username: "testuser",
-  role: Role.USER,
-  createdAt: new Date()
-};
 
 type MockUserWithAccounts = typeof mockUser & {
   accounts: { passwordHash: string }[]

--- a/server/src/tests/auth/logout.test.ts
+++ b/server/src/tests/auth/logout.test.ts
@@ -1,17 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { prisma } from "../../lib/__mocks__/prisma";
 import { logout } from "../../services/auth.service";
+import { mockRefreshTokenRecord } from "../__mocks__/mock-prisma-models";
 
 const mockToken = "refresh_token";
-
-const mockRefreshToken = {
-  id: '1',
-  token: mockToken,
-  revoked: false,
-  createdAt: new Date(),
-  expiresAt: new Date(Date.now() + 24 * 14 * 60 * 60 * 1000),
-  userId: 1,
-};
 
 vi.mock("../../lib/prisma", async () => {
   const actual = await vi.importActual("../../lib/__mocks__/prisma");
@@ -26,7 +18,7 @@ describe("Auth: logout", () => {
   });
 
   it("Should revoke refresh token", async () => {
-    prisma.refreshToken.update.mockResolvedValue({ ...mockRefreshToken, revoked: true });
+    prisma.refreshToken.update.mockResolvedValue({ ...mockRefreshTokenRecord, revoked: true });
 
     await logout({ token: mockToken });
 

--- a/server/src/tests/auth/register.test.ts
+++ b/server/src/tests/auth/register.test.ts
@@ -1,15 +1,7 @@
-import { Role } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { prisma } from "../../lib/__mocks__/prisma";
 import { register } from "../../services/auth.service";
-
-const mockUser = {
-  id: 1,
-  email: "test@example.com",
-  username: "testuser",
-  role: Role.USER,
-  createdAt: new Date()
-};
+import { mockUser } from "../__mocks__/mock-prisma-models";
 
 const mockAccessToken = "access_token";
 const mockRefreshToken = "refresh_token";

--- a/server/src/tests/auth/reset-password.test.ts
+++ b/server/src/tests/auth/reset-password.test.ts
@@ -1,27 +1,10 @@
-import { Role } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { prisma } from "../../lib/__mocks__/prisma";
-import { resetPassword, rotateToken } from "../../services/auth.service";
-
-const mockUser = {
-  id: 1,
-  email: "test@example.com",
-  username: "testuser",
-  role: Role.USER,
-  createdAt: new Date(),
-};
+import { resetPassword } from "../../services/auth.service";
+import { mockUser, mockResetTokenRecord } from "../__mocks__/mock-prisma-models";
 
 const mockResetToken = "reset_token";
 const mockPwHash = "pw_hash";
-
-const mockResetTokenRecord = {
-  id: "1",
-  token: mockResetToken,
-  createdAt: new Date(),
-  expiresAt: new Date(Date.now() + 15 * 60 * 1000),
-  userId: 1,
-  user: mockUser
-}
 
 vi.mock("../../lib/prisma", async () => {
   const actual = await vi.importActual("../../lib/__mocks__/prisma");

--- a/server/src/tests/auth/rotate-token.test.ts
+++ b/server/src/tests/auth/rotate-token.test.ts
@@ -1,31 +1,13 @@
-import { Role } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { prisma } from "../../lib/__mocks__/prisma";
 import { rotateToken } from "../../services/auth.service";
+import { mockRefreshTokenRecord as mockOldToken, mockUser } from "../__mocks__/mock-prisma-models";
 
 const TWO_WEEKS_MS = 1000 * 60 * 60 * 24 * 14;
 
 const mockOldRefreshToken = "old_refresh_token";
 const mockNewRefreshToken = "new_refresh_token";
 const mockNewAccessToken = "new_access_token";
-
-const mockUser = {
-  id: 1,
-  email: "test@example.com",
-  username: "testuser",
-  role: Role.USER,
-  createdAt: new Date(),
-};
-
-const mockOldToken = {
-  id: '1',
-  token: mockOldRefreshToken,
-  revoked: false,
-  createdAt: new Date(),
-  expiresAt: new Date(Date.now() + TWO_WEEKS_MS),
-  userId: 1,
-  user: mockUser,
-};
 
 const mockNewToken = {
   id: '2',

--- a/server/src/tests/mailer/mailer.test.ts
+++ b/server/src/tests/mailer/mailer.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { prisma } from "../../lib/__mocks__/prisma";
+import { resetRequest } from "../../services/mailer.service";
+import { mockResetTokenRecord, mockUser } from "../__mocks__/mock-prisma-models";
+import { mockTransporter } from '../__mocks__/nodemailer';
+
+const mockResetToken = "reset_token";
+
+vi.mock("../../lib/prisma", async () => {
+  const actual = await vi.importActual("../../lib/__mocks__/prisma");
+  return {
+    ...actual,
+  };
+});
+
+vi.mock("nodemailer", async () => {
+  const actual = await vi.importActual("../__mocks__/nodemailer");
+  return {
+    ...actual
+  }
+});
+
+vi.mock('../../utils/issue-tokens.util', () => ({
+  issueResetToken: () => mockResetToken 
+}));
+
+
+describe("Mailer: reset request", () => {
+  const fixedDate = new Date('2025-01-01T00:00:00Z');
+  
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedDate);
+    vi.resetAllMocks();
+  })
+
+  it("Should issue a reset token and send email to user and revoke old tokens", async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
+
+    await resetRequest({ email: mockUser.email });
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: mockUser.email   }
+    })
+
+    expect(prisma.resetToken.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: mockUser.id
+      },
+      data: {
+        revoked: true
+      }
+    })
+
+    expect(prisma.resetToken.create).toHaveBeenCalledWith({
+      data: {
+        token: mockResetToken,
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+        userId: mockUser.id
+      }
+    })
+
+    expect(mockTransporter.sendMail).toHaveBeenCalledOnce();
+  })
+
+  it("User not found should throw error", async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(resetRequest({ email: mockUser.email })).rejects.toThrow("Email not registered.");
+  })
+
+  it("Failure to find user in database should throw error", async () => {
+    prisma.user.findUnique.mockRejectedValue(new Error("Database error"));
+
+    await expect(resetRequest({ email: mockUser.email })).rejects.toThrow("Database error");
+  })
+
+  
+  it("Failure to create reset token in database should throw error", async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
+    prisma.resetToken.create.mockRejectedValue(new Error("Database error"));
+
+    await expect(resetRequest({ email: mockUser.email })).rejects.toThrow("Database error");
+  })
+
+  it("Failure to revoke old reset token in database should throw error", async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
+    prisma.resetToken.updateMany.mockRejectedValue(new Error("Database error"));
+
+    await expect(resetRequest({ email: mockUser.email })).rejects.toThrow("Database error");
+  })
+})


### PR DESCRIPTION
- move mock Prisma models to src/tests/__mocks__/mock-prisma-models
- add mock for nodemailer to src/tests/__mocks__/nodemailer.ts
- add tests for mailer service (resetRequest)
- update existing auth tests to use centralized mocks